### PR TITLE
更新 json unmarshal 型態黑名單

### DIFF
--- a/replaces.go
+++ b/replaces.go
@@ -90,4 +90,6 @@ var replaces []string = []string{
 	"inflated_price",
 	"inflated_original_price",
 	"sip_item_price",
+	"buyer_cancel_reason",
+	"cancel_reason",
 }


### PR DESCRIPTION
由於蝦皮在取得訂單詳細資訊時，在 `buyer_cancel_reason`、`cancel_reason` 時常會出現 0 值，使程式讀取出來 `json.Unmarshal` 會出現這樣的錯誤:

```
 ReadString: expects " or n, but found 0, error found in #10 byte of ...|reason": 0, "recipie|..., bigger context ...|
```

注意於 `reason": 0` 處， reason 原應為字串，但有時系統會回傳數值。

因此對本列表進行更新。